### PR TITLE
Use --dev flag for npm shrinkwrap in dev script

### DIFF
--- a/npm-install-dev
+++ b/npm-install-dev
@@ -2,4 +2,4 @@
 npm prune
 npm install "$@" --save-dev --save-exact
 npm dedupe
-npm shrinkwrap
+npm shrinkwrap --dev


### PR DESCRIPTION
From the npm docs:

> Since "npm shrinkwrap" is intended to lock down your dependencies for
> production use, devDependencies will not be included unless you
> explicitly set the --dev flag when you run npm shrinkwrap.
> If installed devDependencies are excluded, then npm will print a
> warning. If you want them to be installed with your module by default,
> please consider adding them to dependencies instead.

If leaving out `--dev` was intentional, just disregard the PR.
